### PR TITLE
Enhance staff message board

### DIFF
--- a/server/config/database.js
+++ b/server/config/database.js
@@ -145,6 +145,7 @@ async function createTables() {
         content TEXT NOT NULL,
         authorId INT NOT NULL,
         parentId INT,
+        category VARCHAR(50),
         isEdited BOOLEAN DEFAULT FALSE,
         createdAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
         updatedAt TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,

--- a/src/components/staff/MessageBoard.tsx
+++ b/src/components/staff/MessageBoard.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { staffAPI } from '../../services/api';
-import { Plus, Trash2, Reply, ChevronUp, ChevronDown, MessageSquare } from 'lucide-react';
+import { Plus, Trash2, Reply, Pencil, ChevronUp, ChevronDown, MessageSquare } from 'lucide-react';
 import { useAuth } from '../../contexts/AuthContext';
 
 interface MessagePost {
@@ -10,6 +10,9 @@ interface MessagePost {
   authorId: number;
   firstName: string;
   lastName: string;
+  role: string;
+  parentId: number | null;
+  category?: string | null;
   createdAt: string;
   updatedAt: string;
   isEdited: boolean;
@@ -23,11 +26,15 @@ interface MessageReply {
   authorId: number;
   firstName: string;
   lastName: string;
+  role: string;
   createdAt: string;
   updatedAt: string;
   isEdited: boolean;
   parentId: number;
+  category?: string | null;
 }
+
+const categories = ['#build-updates', '#feedback', '#ops', '#general'];
 
 const MessageBoard: React.FC = () => {
   const { user } = useAuth();
@@ -37,7 +44,8 @@ const MessageBoard: React.FC = () => {
   const [expandedPosts, setExpandedPosts] = useState<Set<number>>(new Set());
   const [postReplies, setPostReplies] = useState<Record<number, MessageReply[]>>({});
   const [showMessageForm, setShowMessageForm] = useState(false);
-  const [messageForm, setMessageForm] = useState({ title: '', content: '' });
+  const [editingMessage, setEditingMessage] = useState<MessagePost | null>(null);
+  const [messageForm, setMessageForm] = useState({ title: '', content: '', category: categories[0] });
 
   const loadPosts = async () => {
     try {
@@ -55,8 +63,13 @@ const MessageBoard: React.FC = () => {
   const handleMessagePost = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      await staffAPI.createMessage(messageForm);
-      setMessageForm({ title: '', content: '' });
+      if (editingMessage) {
+        await staffAPI.updateMessage(editingMessage.id, messageForm);
+        setEditingMessage(null);
+      } else {
+        await staffAPI.createMessage(messageForm);
+      }
+      setMessageForm({ title: '', content: '', category: categories[0] });
       setShowMessageForm(false);
       loadPosts();
     } catch (err) {
@@ -73,6 +86,7 @@ const MessageBoard: React.FC = () => {
         title: `Re: ${messagePosts.find(p => p.id === postId)?.title || 'Reply'}`,
         content: replyContent,
         parentId: postId,
+        category: null,
       });
       setReplyForms(prev => ({ ...prev, [postId]: { content: '' } }));
       setShowReplyForm(null);
@@ -123,8 +137,12 @@ const MessageBoard: React.FC = () => {
       <div className="flex justify-between items-center">
         <h2 className="text-2xl font-orbitron font-bold text-white">Staff Message Board</h2>
         <button
-          onClick={() => setShowMessageForm(!showMessageForm)}
-          className="inline-flex items-center px-4 py-2 bg-gradient-to-r from-electric to-neon text-black font-rajdhani font-bold rounded-lg hover:shadow-xl hover:shadow-electric/25 transition-all duration-300"
+          onClick={() => {
+            setEditingMessage(null);
+            setMessageForm({ title: '', content: '', category: categories[0] });
+            setShowMessageForm(!showMessageForm);
+          }}
+          className="inline-flex items-center px-4 py-2 bg-gradient-to-r from-electric to-neon text-black font-rajdhani font-bold rounded-full shadow-md hover:shadow-xl transition-all duration-300"
         >
           <Plus className="h-4 w-4 mr-2" />
           New Post
@@ -133,7 +151,9 @@ const MessageBoard: React.FC = () => {
 
       {showMessageForm && (
         <div className="bg-white/5 backdrop-blur-xl rounded-2xl p-8 border border-white/10">
-          <h3 className="text-xl font-orbitron font-bold mb-6 text-white">Create New Post</h3>
+          <h3 className="text-xl font-orbitron font-bold mb-6 text-white">
+            {editingMessage ? 'Edit Message' : 'Create New Post'}
+          </h3>
           <form onSubmit={handleMessagePost} className="space-y-6">
             <div>
               <label className="block text-sm font-rajdhani font-medium text-gray-200 mb-2">
@@ -148,6 +168,25 @@ const MessageBoard: React.FC = () => {
                 placeholder="Post title..."
               />
             </div>
+
+            {!editingMessage?.parentId && (
+              <div>
+                <label className="block text-sm font-rajdhani font-medium text-gray-200 mb-2">
+                  Category
+                </label>
+                <select
+                  value={messageForm.category}
+                  onChange={(e) => setMessageForm({ ...messageForm, category: e.target.value })}
+                  className="w-full px-4 py-3 bg-white/5 border border-white/20 rounded-lg focus:outline-none focus:ring-2 focus:ring-electric/20 focus:border-electric transition-colors duration-200 font-rajdhani text-white"
+                >
+                  {categories.map((c) => (
+                    <option key={c} value={c} className="bg-black">
+                      {c}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
 
             <div>
               <label className="block text-sm font-rajdhani font-medium text-gray-200 mb-2">
@@ -168,11 +207,14 @@ const MessageBoard: React.FC = () => {
                 type="submit"
                 className="px-6 py-3 bg-gradient-to-r from-electric to-neon text-black font-rajdhani font-bold rounded-lg hover:shadow-xl hover:shadow-electric/25 transition-all duration-300"
               >
-                Post Message
+                {editingMessage ? 'Update' : 'Post Message'}
               </button>
               <button
                 type="button"
-                onClick={() => setShowMessageForm(false)}
+                onClick={() => {
+                  setEditingMessage(null);
+                  setShowMessageForm(false);
+                }}
                 className="px-6 py-3 bg-white/10 text-white font-rajdhani font-bold rounded-lg hover:bg-white/20 transition-colors duration-200"
               >
                 Cancel
@@ -187,14 +229,38 @@ const MessageBoard: React.FC = () => {
           <div key={post.id} className="bg-white/5 backdrop-blur-xl rounded-2xl p-6 border border-white/10">
             <div className="flex justify-between items-start mb-4">
               <div className="flex-1">
-                <h3 className="text-xl font-orbitron font-bold text-white mb-2">{post.title}</h3>
-                <p className="text-gray-300 font-rajdhani text-sm mb-2">
-                  By {post.firstName} {post.lastName} • {new Date(post.createdAt).toLocaleDateString()}
-                  {post.isEdited && <span className="text-gray-500 ml-2">(edited)</span>}
+                <h3 className="text-xl font-orbitron font-bold text-white mb-2 flex items-center space-x-2">
+                  <span>{post.title}</span>
+                  {post.category && (
+                    <span className="text-xs bg-cyber/30 text-cyber px-2 py-0.5 rounded">
+                      {post.category}
+                    </span>
+                  )}
+                </h3>
+                <p className="text-gray-300 font-rajdhani text-sm mb-2 flex items-center space-x-2">
+                  <span>
+                    By {post.firstName} {post.lastName}
+                  </span>
+                  <span className="text-xs bg-white/10 px-2 py-0.5 rounded uppercase">
+                    {post.role}
+                  </span>
+                  <span>• {new Date(post.createdAt).toLocaleDateString('en-GB', { day: '2-digit', month: 'long', year: 'numeric' })}</span>
+                  {post.isEdited && <span className="text-gray-500">(edited)</span>}
                 </p>
               </div>
               {post.authorId === user?.id && (
                 <div className="flex space-x-2">
+                  <button
+                    onClick={() => {
+                      setEditingMessage(post);
+                      setMessageForm({ title: post.title, content: post.content, category: post.category || categories[0] });
+                      setShowMessageForm(true);
+                    }}
+                    className="p-2 bg-white/10 text-white rounded-lg hover:bg-white/20 transition-colors duration-200"
+                    title="Edit"
+                  >
+                    <Pencil className="h-4 w-4" />
+                  </button>
                   <button
                     onClick={() => deleteMessage(post.id)}
                     className="p-2 bg-red-500/20 text-red-400 rounded-lg hover:bg-red-500/30 transition-colors duration-200"
@@ -274,19 +340,34 @@ const MessageBoard: React.FC = () => {
                   <div key={reply.id} className="ml-6 p-4 bg-white/5 rounded-lg border border-white/10">
                     <div className="flex justify-between items-start mb-2">
                       <div>
-                        <p className="text-gray-300 font-rajdhani text-sm">
-                          {reply.firstName} {reply.lastName} • {new Date(reply.createdAt).toLocaleDateString()}
-                          {reply.isEdited && <span className="text-gray-500 ml-2">(edited)</span>}
+                        <p className="text-gray-300 font-rajdhani text-sm flex items-center space-x-2">
+                          <span>{reply.firstName} {reply.lastName}</span>
+                          <span className="text-xs bg-white/10 px-2 py-0.5 rounded uppercase">{reply.role}</span>
+                          <span>• {new Date(reply.createdAt).toLocaleDateString('en-GB', { day: '2-digit', month: 'long', year: 'numeric' })}</span>
+                          {reply.isEdited && <span className="text-gray-500">(edited)</span>}
                         </p>
                       </div>
                       {reply.authorId === user?.id && (
-                        <button
-                          onClick={() => deleteMessage(reply.id)}
-                          className="p-1 bg-red-500/20 text-red-400 rounded hover:bg-red-500/30 transition-colors duration-200"
-                          title="Delete"
-                        >
-                          <Trash2 className="h-3 w-3" />
-                        </button>
+                        <div className="flex space-x-2">
+                          <button
+                            onClick={() => {
+                              setEditingMessage(reply as unknown as MessagePost);
+                              setMessageForm({ title: reply.title, content: reply.content, category: reply.category || categories[0] });
+                              setShowMessageForm(true);
+                            }}
+                            className="p-1 bg-white/10 text-white rounded hover:bg-white/20 transition-colors duration-200"
+                            title="Edit"
+                          >
+                            <Pencil className="h-3 w-3" />
+                          </button>
+                          <button
+                            onClick={() => deleteMessage(reply.id)}
+                            className="p-1 bg-red-500/20 text-red-400 rounded hover:bg-red-500/30 transition-colors duration-200"
+                            title="Delete"
+                          >
+                            <Trash2 className="h-3 w-3" />
+                          </button>
+                        </div>
                       )}
                     </div>
                     <p className="text-gray-300 font-rajdhani whitespace-pre-wrap">{reply.content}</p>

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -101,6 +101,7 @@ export const staffAPI = {
   // Messages
   getMessages: () => api.get('/staff/messages'),
   createMessage: (data: any) => api.post('/staff/messages', data),
+  updateMessage: (id: number, data: any) => api.put(`/staff/messages/${id}`, data),
   getReplies: (postId: number) => api.get(`/staff/messages/${postId}/replies`),
   deleteMessage: (id: number) => api.delete(`/staff/messages/${id}`),
   


### PR DESCRIPTION
## Summary
- support `category` column in `message_posts` table
- allow editing messages with new API endpoint
- show roles, category badges, and formatted dates on messages
- add inline edit buttons and category selector in the message board
- update API helpers for message updates

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_686898a7238c832c9180f436f683162b