### PR TITLE
Add contract request overview for admins

### DIFF
--- a/server/config/database.js
+++ b/server/config/database.js
@@ -343,13 +343,15 @@ async function createTables() {
         id INT AUTO_INCREMENT PRIMARY KEY,
         user_id INT NOT NULL,
         template_id INT NOT NULL,
+        assigned_by INT,
         status ENUM('pending','signed') DEFAULT 'pending',
         signed_at TIMESTAMP NULL,
         signed_name VARCHAR(255),
         signed_ip VARCHAR(45),
         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
         FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
-        FOREIGN KEY (template_id) REFERENCES contract_templates(id) ON DELETE CASCADE
+        FOREIGN KEY (template_id) REFERENCES contract_templates(id) ON DELETE CASCADE,
+        FOREIGN KEY (assigned_by) REFERENCES users(id) ON DELETE SET NULL
       )
     `);
     

--- a/src/components/contracts/ContractRequests.tsx
+++ b/src/components/contracts/ContractRequests.tsx
@@ -1,0 +1,51 @@
+import React, { useEffect, useState } from 'react';
+import { contractAPI } from '../../services/api';
+
+interface Request {
+  id: number;
+  type: string;
+  message: string;
+  created_at: string;
+  contract_id: number;
+  user_id: number;
+  firstName: string;
+  lastName: string;
+  title: string;
+}
+
+const ContractRequests: React.FC = () => {
+  const [requests, setRequests] = useState<Request[]>([]);
+
+  const load = async () => {
+    try {
+      const res = await contractAPI.getRequests();
+      setRequests(res.data);
+    } catch (err) {
+      console.error('Failed to load requests', err);
+    }
+  };
+
+  useEffect(() => { load(); }, []);
+
+  return (
+    <div className="p-6 space-y-4">
+      <h2 className="font-orbitron text-2xl font-bold mb-4">Contract Requests</h2>
+      <ul className="space-y-4">
+        {requests.map(r => (
+          <li key={r.id} className="border border-gray-700 rounded-lg p-4">
+            <div className="font-rajdhani font-bold text-white">{r.title}</div>
+            <div className="text-sm text-gray-400">
+              {r.firstName} {r.lastName} - {r.type}
+            </div>
+            {r.message && <p className="mt-2 text-gray-300">{r.message}</p>}
+            <div className="text-xs text-gray-500">
+              {new Date(r.created_at).toLocaleString()}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default ContractRequests;

--- a/src/pages/ContractsPage.tsx
+++ b/src/pages/ContractsPage.tsx
@@ -6,6 +6,7 @@ import MyContracts from '../components/contracts/MyContracts';
 import ContractEditor from '../components/contracts/ContractEditor';
 import AssignContract from '../components/contracts/AssignContract';
 import ViewUserContracts from '../components/contracts/ViewUserContracts';
+import ContractRequests from '../components/contracts/ContractRequests';
 
 const ContractsPage: React.FC = () => {
   const { user } = useAuth();
@@ -20,7 +21,8 @@ const ContractsPage: React.FC = () => {
     tabs.push(
       { id: 'templates', label: 'Templates', component: ContractEditor },
       { id: 'assign', label: 'Assign', component: AssignContract },
-      { id: 'view', label: 'View User', component: ViewUserContracts }
+      { id: 'view', label: 'View User', component: ViewUserContracts },
+      { id: 'requests', label: 'Requests', component: ContractRequests }
     );
   }
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -149,6 +149,7 @@ export const contractAPI = {
     api.post(`/contracts/sign/${id}`, { fullName }),
   requestChange: (data: { contractId: number; type: string; message: string }) =>
     api.post('/contracts/request', data),
+  getRequests: () => api.get('/contracts/requests'),
 };
 
 // Admin API


### PR DESCRIPTION
## Summary
- record who assigned a contract
- allow admins/CEOs to retrieve contract change requests
- expose `getRequests` in contract API
- show requests tab in Contracts page
- display request list

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6868a0486e48832cb2755d91e4529e86