### PR TITLE
Add request resolution support

### DIFF
--- a/server/config/database.js
+++ b/server/config/database.js
@@ -343,13 +343,15 @@ async function createTables() {
         id INT AUTO_INCREMENT PRIMARY KEY,
         user_id INT NOT NULL,
         template_id INT NOT NULL,
+        assigned_by INT,
         status ENUM('pending','signed') DEFAULT 'pending',
         signed_at TIMESTAMP NULL,
         signed_name VARCHAR(255),
         signed_ip VARCHAR(45),
         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
         FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
-        FOREIGN KEY (template_id) REFERENCES contract_templates(id) ON DELETE CASCADE
+        FOREIGN KEY (template_id) REFERENCES contract_templates(id) ON DELETE CASCADE,
+        FOREIGN KEY (assigned_by) REFERENCES users(id) ON DELETE SET NULL
       )
     `);
     
@@ -360,8 +362,12 @@ async function createTables() {
         user_contract_id INT NOT NULL,
         type ENUM('amend','appeal','leave') NOT NULL,
         message TEXT,
+        status ENUM('open','resolved') DEFAULT 'open',
+        resolved_by INT,
+        resolved_at TIMESTAMP NULL,
         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-        FOREIGN KEY (user_contract_id) REFERENCES user_contracts(id) ON DELETE CASCADE
+        FOREIGN KEY (user_contract_id) REFERENCES user_contracts(id) ON DELETE CASCADE,
+        FOREIGN KEY (resolved_by) REFERENCES users(id) ON DELETE SET NULL
       )
     `);
     // Insert default company info if not exists

--- a/server/routes/contracts.js
+++ b/server/routes/contracts.js
@@ -39,8 +39,8 @@ router.post('/assign', authenticateToken, requireAdmin, async (req, res) => {
   try {
     const { userId, templateId } = req.body;
     await pool.execute(
-      'INSERT INTO user_contracts (user_id, template_id) VALUES (?, ?)',
-      [userId, templateId]
+      'INSERT INTO user_contracts (user_id, template_id, assigned_by) VALUES (?, ?, ?)',
+      [userId, templateId, req.user.id]
     );
     res.status(201).json({ message: 'Contract assigned' });
   } catch (err) {
@@ -169,6 +169,87 @@ router.post('/request', authenticateToken, requireStaff, async (req, res) => {
     res.json({ message: 'Request submitted' });
   } catch (err) {
     console.error('Contract request error:', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// List contract requests for admin/ceo
+router.get('/requests', authenticateToken, requireAdmin, async (req, res) => {
+  try {
+    let query = `
+      SELECT cr.id, cr.type, cr.message, cr.created_at,
+             uc.id AS contract_id, uc.user_id, uc.assigned_by,
+             u.firstName, u.lastName,
+             ct.title
+        FROM contract_requests cr
+        JOIN user_contracts uc ON cr.user_contract_id = uc.id
+        JOIN users u ON uc.user_id = u.id
+        JOIN contract_templates ct ON uc.template_id = ct.id
+        WHERE cr.status='open'`;
+    const params = [];
+
+    if (req.user.role === 'admin') {
+      query += ' AND uc.assigned_by = ?';
+      params.push(req.user.id);
+    }
+
+    query += ' ORDER BY cr.created_at DESC';
+
+    const [rows] = await pool.execute(query, params);
+    res.json(rows);
+  } catch (err) {
+    console.error('List contract requests error:', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+router.post('/requests/:id/resolve', authenticateToken, async (req, res) => {
+  try {
+    const { id } = req.params;
+
+    const [rows] = await pool.execute(
+      `SELECT cr.status, uc.user_id
+         FROM contract_requests cr
+         JOIN user_contracts uc ON cr.user_contract_id = uc.id
+        WHERE cr.id=?`,
+      [id]
+    );
+
+    if (rows.length === 0) {
+      return res.status(404).json({ error: 'Request not found' });
+    }
+
+    const request = rows[0];
+
+    if (request.status === 'resolved') {
+      return res.json({ message: 'Already resolved' });
+    }
+
+    if (
+      req.user.role === 'staff' &&
+      req.user.id !== request.user_id
+    ) {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+
+    if (
+      req.user.role !== 'staff' &&
+      req.user.role !== 'admin' &&
+      req.user.role !== 'ceo'
+    ) {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+
+    await pool.execute(
+      `UPDATE contract_requests
+          SET status='resolved', resolved_by=?, resolved_at=NOW()
+        WHERE id=?`,
+      [req.user.id, id]
+    );
+
+    res.json({ message: 'Request resolved' });
+  } catch (err) {
+    console.error('Resolve contract request error:', err);
     res.status(500).json({ error: 'Internal server error' });
   }
 });

--- a/src/components/contracts/ContractRequests.tsx
+++ b/src/components/contracts/ContractRequests.tsx
@@ -1,0 +1,68 @@
+import React, { useEffect, useState } from 'react';
+import { contractAPI } from '../../services/api';
+
+interface Request {
+  id: number;
+  type: string;
+  message: string;
+  created_at: string;
+  contract_id: number;
+  user_id: number;
+  firstName: string;
+  lastName: string;
+  title: string;
+}
+
+const ContractRequests: React.FC = () => {
+  const [requests, setRequests] = useState<Request[]>([]);
+
+  const load = async () => {
+    try {
+      const res = await contractAPI.getRequests();
+      setRequests(res.data);
+    } catch (err) {
+      console.error('Failed to load requests', err);
+    }
+  };
+
+  const resolve = async (id: number) => {
+    try {
+      await contractAPI.resolveRequest(id);
+      await load();
+    } catch (err) {
+      console.error('Failed to resolve request', err);
+    }
+  };
+
+  useEffect(() => { load(); }, []);
+
+  return (
+    <div className="p-6 space-y-4">
+      <h2 className="font-orbitron text-2xl font-bold mb-4">Contract Requests</h2>
+      <ul className="space-y-4">
+        {requests.map(r => (
+          <li key={r.id} className="border border-gray-700 rounded-lg p-4">
+            <div className="font-rajdhani font-bold text-white">{r.title}</div>
+            <div className="text-sm text-gray-400">
+              {r.firstName} {r.lastName} - {r.type}
+            </div>
+            {r.message && <p className="mt-2 text-gray-300">{r.message}</p>}
+            <div className="flex justify-between items-end mt-2">
+              <span className="text-xs text-gray-500">
+                {new Date(r.created_at).toLocaleString()}
+              </span>
+              <button
+                onClick={() => resolve(r.id)}
+                className="text-sm text-blue-400 hover:underline"
+              >
+                Resolve
+              </button>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default ContractRequests;

--- a/src/pages/ContractsPage.tsx
+++ b/src/pages/ContractsPage.tsx
@@ -6,6 +6,7 @@ import MyContracts from '../components/contracts/MyContracts';
 import ContractEditor from '../components/contracts/ContractEditor';
 import AssignContract from '../components/contracts/AssignContract';
 import ViewUserContracts from '../components/contracts/ViewUserContracts';
+import ContractRequests from '../components/contracts/ContractRequests';
 
 const ContractsPage: React.FC = () => {
   const { user } = useAuth();
@@ -20,7 +21,8 @@ const ContractsPage: React.FC = () => {
     tabs.push(
       { id: 'templates', label: 'Templates', component: ContractEditor },
       { id: 'assign', label: 'Assign', component: AssignContract },
-      { id: 'view', label: 'View User', component: ViewUserContracts }
+      { id: 'view', label: 'View User', component: ViewUserContracts },
+      { id: 'requests', label: 'Requests', component: ContractRequests }
     );
   }
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -149,6 +149,8 @@ export const contractAPI = {
     api.post(`/contracts/sign/${id}`, { fullName }),
   requestChange: (data: { contractId: number; type: string; message: string }) =>
     api.post('/contracts/request', data),
+  getRequests: () => api.get('/contracts/requests'),
+  resolveRequest: (id: number) => api.post(`/contracts/requests/${id}/resolve`),
 };
 
 // Admin API


### PR DESCRIPTION
## Summary
- extend database to track resolved contract requests
- list only open requests in admin view
- admins, CEOs or the contract owner can mark requests as resolved
- expose `resolveRequest` API call and show Resolve button in request list

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_6868a0486e48832cb2755d91e4529e86