### PR TITLE
Implement contract request workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A modern, full-stack web application for MuseFuze Studios featuring user authent
 - **Message Board** - Team communication and collaboration
 - **Playtest Sessions** - Schedule and manage testing sessions
 - **Download History** - Track build downloads and usage
+- **Contracts** - View, sign and manage legally binding agreements
 
 ### Admin Features
 - **User Management** - Manage user accounts and roles
@@ -30,6 +31,12 @@ A modern, full-stack web application for MuseFuze Studios featuring user authent
 - **Finance Tracking** - Budget management and expense tracking
 - **System Monitoring** - Server health and system logs
 - **Feature Toggles** - Control experimental features
+
+### Contract Management
+- Assign contracts based on templates
+- Digital signing with name, IP and timestamp logging
+- Users can request amendments, appeals or to leave a contract
+- Staff review requests and archive or update contracts accordingly
 
 ## 🛠️ Tech Stack
 

--- a/src/components/contracts/ContractRequests.tsx
+++ b/src/components/contracts/ContractRequests.tsx
@@ -11,14 +11,17 @@ interface Request {
   firstName: string;
   lastName: string;
   title: string;
+  outcome?: string;
+  notes?: string;
 }
 
 const ContractRequests: React.FC = () => {
   const [requests, setRequests] = useState<Request[]>([]);
+  const [filter, setFilter] = useState('all');
 
   const load = async () => {
     try {
-      const res = await contractAPI.getRequests();
+      const res = await contractAPI.getRequests(filter !== 'all' ? filter : undefined);
       setRequests(res.data);
     } catch (err) {
       console.error('Failed to load requests', err);
@@ -26,19 +29,31 @@ const ContractRequests: React.FC = () => {
   };
 
   const resolve = async (id: number) => {
+    const outcome = window.prompt('Outcome (approved/denied)', 'approved') || 'approved';
+    const notes = window.prompt('Notes', '') || '';
     try {
-      await contractAPI.resolveRequest(id);
+      await contractAPI.resolveRequest(id, { outcome, notes });
       await load();
     } catch (err) {
       console.error('Failed to resolve request', err);
     }
   };
 
-  useEffect(() => { load(); }, []);
+  useEffect(() => { load(); }, [filter]);
 
   return (
     <div className="p-6 space-y-4">
       <h2 className="font-orbitron text-2xl font-bold mb-4">Contract Requests</h2>
+      <select
+        value={filter}
+        onChange={e => setFilter(e.target.value)}
+        className="px-2 py-1 bg-gray-800 border border-gray-700 rounded-lg"
+      >
+        <option value="all">All</option>
+        <option value="leave">Leave</option>
+        <option value="amend">Amend</option>
+        <option value="appeal">Appeal</option>
+      </select>
       <ul className="space-y-4">
         {requests.map(r => (
           <li key={r.id} className="border border-gray-700 rounded-lg p-4">

--- a/src/components/contracts/MyContracts.tsx
+++ b/src/components/contracts/MyContracts.tsx
@@ -10,6 +10,7 @@ interface Contract {
   content: string;
   signed_at: string | null;
   signed_name?: string;
+  is_active: boolean;
 }
 
 const MyContracts: React.FC = () => {
@@ -45,9 +46,11 @@ const MyContracts: React.FC = () => {
           <li key={c.id} className="border border-gray-700 rounded-xl p-4 flex justify-between items-center">
             <div>
               <h3 className="font-rajdhani font-bold text-white">{c.title}</h3>
-              <p className="text-gray-400 text-sm">Status: {c.status}</p>
+              <p className="text-gray-400 text-sm">
+                Status: {c.status} {c.is_active ? '' : '(inactive)'}
+              </p>
             </div>
-            {c.status === 'pending' ? (
+            {c.status === 'pending' && c.is_active ? (
               <button
                 onClick={() => setActive(c)}
                 className="px-4 py-2 bg-gradient-to-r from-electric to-neon text-black rounded-lg font-rajdhani font-bold"

--- a/src/components/contracts/ViewContract.tsx
+++ b/src/components/contracts/ViewContract.tsx
@@ -9,6 +9,7 @@ interface Contract {
   signed_at: string | null;
   signed_name?: string;
   signed_ip?: string;
+  is_active: boolean;
 }
 
 interface Props {
@@ -47,29 +48,33 @@ const ViewContract: React.FC<Props> = ({ contract, onClose }) => {
           {contract.signed_ip && <div>IP: {contract.signed_ip}</div>}
         </div>
       )}
-      {sent ? (
-        <p className="text-green-400">Request submitted.</p>
-      ) : (
-        <div className="space-y-4">
-          <div className="flex gap-2">
-            <select value={type} onChange={e => setType(e.target.value)} className="px-2 py-1 bg-gray-800 border border-gray-700 rounded-lg">
-              <option value="amend">Request Amendment</option>
-              <option value="appeal">Appeal</option>
-              <option value="leave">Leave Contract</option>
-            </select>
-            <button onClick={() => setSent(false)} className="hidden" />
+      {contract.is_active ? (
+        sent ? (
+          <p className="text-green-400">Request submitted.</p>
+        ) : (
+          <div className="space-y-4">
+            <div className="flex gap-2">
+              <select value={type} onChange={e => setType(e.target.value)} className="px-2 py-1 bg-gray-800 border border-gray-700 rounded-lg">
+                <option value="amend">Request Amendment</option>
+                <option value="appeal">Appeal</option>
+                <option value="leave">Leave Contract</option>
+              </select>
+              <button onClick={() => setSent(false)} className="hidden" />
+            </div>
+            <textarea
+              value={message}
+              onChange={e => setMessage(e.target.value)}
+              className="w-full h-24 p-2 bg-gray-800 border border-gray-700 rounded-lg"
+              placeholder="Additional details (optional)"
+            />
+            {error && <p className="text-red-400 text-sm">{error}</p>}
+            <button onClick={submit} disabled={loading} className="px-6 py-2 bg-gradient-to-r from-electric to-neon text-black rounded-lg font-rajdhani font-bold disabled:opacity-50">
+              {loading ? 'Sending...' : 'Submit Request'}
+            </button>
           </div>
-          <textarea
-            value={message}
-            onChange={e => setMessage(e.target.value)}
-            className="w-full h-24 p-2 bg-gray-800 border border-gray-700 rounded-lg"
-            placeholder="Additional details (optional)"
-          />
-          {error && <p className="text-red-400 text-sm">{error}</p>}
-          <button onClick={submit} disabled={loading} className="px-6 py-2 bg-gradient-to-r from-electric to-neon text-black rounded-lg font-rajdhani font-bold disabled:opacity-50">
-            {loading ? 'Sending...' : 'Submit Request'}
-          </button>
-        </div>
+        )
+      ) : (
+        <p className="text-gray-400">This contract is inactive.</p>
       )}
       <button onClick={onClose} className="text-gray-400 ml-4">Close</button>
     </div>

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -149,8 +149,10 @@ export const contractAPI = {
     api.post(`/contracts/sign/${id}`, { fullName }),
   requestChange: (data: { contractId: number; type: string; message: string }) =>
     api.post('/contracts/request', data),
-  getRequests: () => api.get('/contracts/requests'),
-  resolveRequest: (id: number) => api.post(`/contracts/requests/${id}/resolve`),
+  getRequests: (type?: string) =>
+    api.get('/contracts/requests', { params: type ? { type } : {} }),
+  resolveRequest: (id: number, data: { outcome: string; notes: string }) =>
+    api.post(`/contracts/requests/${id}/resolve`, data),
 };
 
 // Admin API


### PR DESCRIPTION
## Summary
- extend contract system with leave/amend/appeal workflow
- track contract state in new `contract_logs` table
- allow filtering and resolving contract requests via dashboard
- display inactive contracts and prevent actions
- document contract management in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686956bc9b70832c84c834ab98d59e65